### PR TITLE
Fixes: Documetation, Request rates

### DIFF
--- a/.github/workflows/on-tag-updating.yml
+++ b/.github/workflows/on-tag-updating.yml
@@ -1,0 +1,21 @@
+name: Running example
+on: [push]
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+
+jobs:
+  deploy:
+    name: 'Deployment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Executing AWS CodeBuild task
+        uses: dark-mechanicum/aws-codebuild@1
+        with:
+          projectName: '<your-aws-codebuild-job-name-here>'
+        env:
+          CODEBUILD__environmentVariablesOverride: '[
+            { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
+          ]'

--- a/.github/workflows/on-tag-updating.yml
+++ b/.github/workflows/on-tag-updating.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Executing AWS CodeBuild task
-        uses: dark-mechanicum/aws-codebuild@1
+        uses: dark-mechanicum/aws-codebuild@v1
         with:
           projectName: '<your-aws-codebuild-job-name-here>'
         env:

--- a/.github/workflows/on-tag-updating.yml
+++ b/.github/workflows/on-tag-updating.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Executing AWS CodeBuild task
         uses: dark-mechanicum/aws-codebuild@v1
         with:
-          projectName: '<your-aws-codebuild-job-name-here>'
+          projectName: 'testing-codebuild-logs'
         env:
           CODEBUILD__environmentVariablesOverride: '[
             { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Running example
-on: [push]
+on: [release]
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -3,15 +3,23 @@
 Simple, but very powerful GitHub Action to trigger AWS CodeBuild jobs with overrides all parameters and job execution log output.
 
 ```yaml
+name: Running example
+on: [push]
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ${{ secrets.AWS_REGION }}
 
-- name: AWS CodeBuild Job
-  uses: dark-mechanicum/aws-codebuild@1
-  with:
-    projectName: '<your-aws-codebuild-job-name-here>'
+jobs:
+  deploy:
+    name: 'Deployment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Executing AWS CodeBuild task
+        uses: dark-mechanicum/aws-codebuild@1
+        with:
+          projectName: '<your-aws-codebuild-job-name-here>'
 ```
 
 ## Description
@@ -41,7 +49,7 @@ Setting up credentials files ([AWS Documentation](https://docs.aws.amazon.com/sd
 - name: AWS CodeBuild Job
   uses: dark-mechanicum/aws-codebuild@1
   with:
-  projectName: '<your-aws-codebuild-job-name-here>'
+    projectName: '<your-aws-codebuild-job-name-here>'
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Executing AWS CodeBuild task
-        uses: dark-mechanicum/aws-codebuild@1
+        uses: dark-mechanicum/aws-codebuild@v1
         with:
           projectName: '<your-aws-codebuild-job-name-here>'
 ```
@@ -47,7 +47,7 @@ Setting up credentials files ([AWS Documentation](https://docs.aws.amazon.com/sd
     aws-region: ${{ secrets.AWS_REGION }}
 
 - name: AWS CodeBuild Job
-  uses: dark-mechanicum/aws-codebuild@1
+  uses: dark-mechanicum/aws-codebuild@v1
   with:
     projectName: '<your-aws-codebuild-job-name-here>'
 ```
@@ -62,7 +62,7 @@ To example, if you want to override `environmentVariablesOverride` property (it 
 
 ```yaml
 - name: AWS CodeBuild Job
-  uses: dark-mechanicum/aws-codebuild@1
+  uses: dark-mechanicum/aws-codebuild@v1
   with:
     projectName: '<your-aws-codebuild-job-name-here>'
   env:
@@ -75,7 +75,7 @@ To example, if you want to override `environmentVariablesOverride` property (it 
 In case, if configuration option do not have a complex type, you can define single environment variable with required to you value. 
 ```yaml
 - name: AWS CodeBuild Job
-  uses: dark-mechanicum/aws-codebuild@1
+  uses: dark-mechanicum/aws-codebuild@v1
   with:
     projectName: '<your-aws-codebuild-job-name-here>'
   env:

--- a/src/codebuildjob.ts
+++ b/src/codebuildjob.ts
@@ -69,7 +69,7 @@ class CodeBuildJob extends EventEmitter {
     }
 
     if (this.currentPhase !== 'COMPLETED') {
-      this.timeout = setTimeout(this.wait, 1000);
+      this.timeout = setTimeout(this.wait, 20000);
     }
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -65,7 +65,7 @@ class CloudWatchLogger extends EventEmitter {
     }
 
     if (!this.isStopping) {
-      this.timeout = setTimeout(this.startListen, 1000);
+      this.timeout = setTimeout(this.startListen, 10000);
     }
   }
 


### PR DESCRIPTION
Updated documentation and decreased request rates to the AWS API. By default, the job status will be updated once at 20 seconds, and logs in 10 seconds.

Also added GitHub actions workflow for the releases to verify that published release can be triggered and executed