### PR TITLE
Move codebuild status updates outside of logger functionality

### DIFF
--- a/__tests__/src/codebuildjob/CodeBuildJob.ts
+++ b/__tests__/src/codebuildjob/CodeBuildJob.ts
@@ -100,6 +100,59 @@ describe('CodeBuildJob class functionality', () => {
     expect(loggerStop).toBeCalled();
   });
 
+  it('should complete whole cycle successfully without logs', async () => {
+    const { startBuild, batchGetBuilds, stopBuild, loggerStart, loggerStop } = mocks;
+    const [onPhaseChanged, onCOMPLETED] = [jest.fn(), jest.fn()];
+    const job = new CodeBuildJob({ projectName: 'test' });
+
+    job.on('phaseChanged', onPhaseChanged);
+    job.on('COMPLETED', onCOMPLETED);
+
+    startBuild.mockReturnValueOnce(createAWSResponse({
+      build: {
+        id: 'test:testStreamID',
+        logs: { cloudWatchLogs: { status: 'DISABLED' } },
+      },
+    } as StartBuildOutput));
+
+    stopBuild.mockReturnValue(createAWSResponse({ build: {} } as StopBuildOutput));
+
+    batchGetBuilds
+    .mockReturnValueOnce(createAWSResponse({ builds: [ { currentPhase: 'QUEUED' as BuildPhaseType } ] } as BatchGetBuildsOutput))
+    .mockReturnValueOnce(createAWSResponse({ builds: [ { currentPhase: 'PROVISIONING' as BuildPhaseType } ] } as BatchGetBuildsOutput))
+    .mockReturnValueOnce(createAWSResponse({ builds: [ { currentPhase: 'BUILD' as BuildPhaseType } ] } as BatchGetBuildsOutput))
+    .mockReturnValueOnce(createAWSResponse({ builds: [ { currentPhase: 'COMPLETED' as BuildPhaseType } ] } as BatchGetBuildsOutput))
+
+    await job.startBuild();
+    expect(onPhaseChanged).toHaveBeenLastCalledWith('QUEUED');
+    expect(onCOMPLETED).not.toBeCalled();
+    expect(loggerStart).not.toBeCalled();
+
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+
+    expect(onPhaseChanged).toHaveBeenLastCalledWith('PROVISIONING');
+    expect(onCOMPLETED).not.toBeCalled();
+    expect(loggerStart).not.toBeCalled();
+
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+
+    expect(onPhaseChanged).toHaveBeenLastCalledWith('BUILD');
+    expect(onCOMPLETED).not.toBeCalled();
+    expect(loggerStart).not.toBeCalled();
+
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+
+    expect(onPhaseChanged).toHaveBeenLastCalledWith('COMPLETED');
+    expect(onCOMPLETED).toBeCalled();
+
+    await job.cancelBuild();
+    expect(stopBuild).toBeCalled();
+    expect(loggerStop).not.toBeCalled();
+  });
+
   it('should trigger exception if codebuild job can not be started', async () => {
     const { startBuild } = mocks;
     const job = new CodeBuildJob({ projectName: 'test' });


### PR DESCRIPTION
Move AWS CodeBuild status updates wait method outside of logger initialization branches.