### PR TITLE
Added additional inputs support

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -55,6 +55,36 @@ jobs:
         uses: ./
         with:
           projectName: 'testing-codebuild-logs'
+          buildspec: '{
+            "environmentVariablesOverride":[
+              { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
+            ],
+            "logsConfigOverride": {
+              "cloudWatchLogs": {
+                "status": "ENABLED"
+              }
+            }
+          }'
+
+  env_var_using:
+    name: Run env var using scenario
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Executing AWS CodeBuild task
+        uses: ./
+        with:
+          projectName: 'testing-codebuild-logs'
         env:
           CODEBUILD__environmentVariablesOverride: '[
             { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,6 +1,11 @@
 name: Validation
 on: [push]
 
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: us-east-1
+
 jobs:
   build:
     name: Verifying
@@ -33,22 +38,99 @@ jobs:
       - name: Run unit tests
         run: npm run test
 
-  planning:
-    name: Executing AWS CodeBuild Job
+  simple:
+    name: Run simple scenario
     runs-on: ubuntu-latest
     needs: [ build ]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Executing AWS CodeBuild task
         uses: ./
         with:
           projectName: 'testing-codebuild-logs'
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
+          CODEBUILD__environmentVariablesOverride: '[
+            { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
+          ]'
+
+  without_wait:
+    name: Run without waiting job scenario
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Executing AWS CodeBuild task
+        uses: ./
+        with:
+          projectName: 'testing-codebuild-logs'
+          waitToBuildEnd: false
+          CODEBUILD__environmentVariablesOverride: '[
+            { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
+          ]'
+
+  without_logs:
+    name: Run without logs scenario
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Executing AWS CodeBuild task
+        uses: ./
+        with:
+          projectName: 'testing-codebuild-logs'
+          displayBuildLogs: false
+          CODEBUILD__environmentVariablesOverride: '[
+            { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
+          ]'
+
+  fast:
+    name: Run fast scenario
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Executing AWS CodeBuild task
+        uses: ./
+        with:
+          projectName: 'testing-codebuild-logs'
+          buildStatusInterval: 1000
+          logsUpdateInterval: 1000
           CODEBUILD__environmentVariablesOverride: '[
             { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
           ]'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task
@@ -71,8 +71,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task
@@ -95,8 +95,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task
@@ -119,8 +119,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,8 +2,6 @@ name: Validation
 on: [push]
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: us-east-1
 
 jobs:
@@ -49,8 +47,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task
@@ -73,8 +71,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task
@@ -97,8 +95,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task
@@ -121,8 +119,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secret.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secret.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Executing AWS CodeBuild task

--- a/README.md
+++ b/README.md
@@ -43,13 +43,24 @@ In case if you have enabled AWS CloudWatch logs for AWS CodeBuild job execution,
     logsUpdateInterval: 5000
     waitToBuildEnd: true
     displayBuildLogs: true
+    buildspec: '{
+      "environmentVariablesOverride":[
+        { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
+      ],
+      "logsConfigOverride": {
+        "cloudWatchLogs": {
+          "status": "ENABLED"
+        }
+      }
+    }'
 ```
 
 * `projectName` [string] [required] - The name of the CodeBuild build project to start running a build
 * `buildStatusInterval` [number] [optional] - Interval in milliseconds to control how often should be checked status of build
 * `logsUpdateInterval` [number] [optional] - Interval in milliseconds to control how often should be checked new events in logs stream
-* `waitToBuildEnd` [number] [boolean] - Wait till AWS CodeBuild job will be finished
-* `displayBuildLogs` [number] [boolean] - Display AWS CodeBuild logs output in the GitHub Actions logs output
+* `waitToBuildEnd` [boolean] [optional] - Wait till AWS CodeBuild job will be finished
+* `displayBuildLogs` [boolean] [optional] - Display AWS CodeBuild logs output in the GitHub Actions logs output
+* `buildspec` [string] [optional] - Custom parameters to override job parameters in the valid JSON format. Full list of supported paramters you can find in the [CodeBuild.startBuild()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodeBuild.html#startBuild-property) documentation
 
 ## AWS Credentials
 
@@ -80,8 +91,29 @@ Setting up credentials files ([AWS Documentation](https://docs.aws.amazon.com/sd
 ## Configuration
 Unfortunately, [GitHub Actions syntax](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions) do not support complex data types. I've made a decision to use environment variables for building configuration object overrides. It means, you can extend configuration for your AWS CodeBuild Job request with using of environment variables.
 
-For overriding AWS CodeBuild Job request parameters, you need to define environment variable `CODEBUILD__environmentVariablesOverride` and assign complex and valid JSON value to that variable.
+Most elegant way to implement overriding of [CodeBuild.startBuild()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodeBuild.html#startBuild-property) is using `buildspec` input. The `buildspec` input should contain valid JSON object with values that you are planning to override.
 
+```yaml
+- name: Executing AWS CodeBuild task
+  uses: dark-mechanicum/aws-codebuild@v1
+  with:
+    projectName: '<your-aws-codebuild-job-name-here>'
+    buildspec: '{
+      "environmentVariablesOverride":[
+        { "name":"testEnvVar1", "value":"Testing environment variable", "type": "PLAINTEXT" },
+        { "name":"testEnvVar2", "value":"${{ secrets.SOME_SECRET }}", "type": "PLAINTEXT" },
+      ],
+      "logsConfigOverride": {
+        "cloudWatchLogs": {
+          "status": "ENABLED"
+        }
+      }
+    }'
+```
+
+---
+
+For overriding through environment variables, you need to define environment variable `CODEBUILD__environmentVariablesOverride` and assign complex and valid JSON value to that variable.
 
 To example, if you want to override `environmentVariablesOverride` property (it requires array of objects), you need define `CODEBUILD__environmentVariablesOverride` and assign to it required JSON value 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ In case if AWS CodeBuild job execution will be failed, it also will fail executi
 
 In case if you have enabled AWS CloudWatch logs for AWS CodeBuild job execution, it will put AWS CloudWatch logs output in the GitHub Actions logs output.
 
+## Inputs
+```yaml
+- name: Executing AWS CodeBuild task
+  uses: dark-mechanicum/aws-codebuild@v1
+  with:
+    projectName: '<your-aws-codebuild-job-name-here>'
+    buildStatusInterval: 5000
+    logsUpdateInterval: 5000
+    waitToBuildEnd: true
+    displayBuildLogs: true
+```
+
+* `projectName` [string] [required] - The name of the CodeBuild build project to start running a build
+* `buildStatusInterval` [number] [optional] - Interval in milliseconds to control how often should be checked status of build
+* `logsUpdateInterval` [number] [optional] - Interval in milliseconds to control how often should be checked new events in logs stream
+* `waitToBuildEnd` [number] [boolean] - Wait till AWS CodeBuild job will be finished
+* `displayBuildLogs` [number] [boolean] - Display AWS CodeBuild logs output in the GitHub Actions logs output
+
 ## AWS Credentials
 
 You can use 2 ways how to put AWS access credentials to this action:

--- a/__tests__/src/index/main.ts
+++ b/__tests__/src/index/main.ts
@@ -59,6 +59,7 @@ describe('CodeBuildJob class functionality', () => {
         case 'projectName': return 'test';
         case 'buildStatusInterval': return '5000';
         case 'logsUpdateInterval': return '5000';
+        case 'buildspec': return '{}';
         default: return '';
       }
     });
@@ -87,7 +88,7 @@ describe('CodeBuildJob class functionality', () => {
   it('should cancel job on SIGINT signal', async () => {
     const { startBuild, actionsCoreGetInput, cancelBuild } = mocks;
     startBuild.mockReturnValue({ catch: jest.fn() });
-    actionsCoreGetInput.mockReturnValue('test');
+    actionsCoreGetInput.mockImplementation((val: string): string => val === 'buildspec' ? '{}' : 'test');
     require('../../../src/index');
 
     jest.spyOn(process, 'exit').mockImplementation(jest.fn().mockName('Mock process.exit()') as never);
@@ -98,7 +99,7 @@ describe('CodeBuildJob class functionality', () => {
   it('should try to cancel job on SIGINT signal with exception', async () => {
     const { startBuild, actionsCoreGetInput, cancelBuild, actionsCoreError } = mocks;
     startBuild.mockReturnValue({ catch: jest.fn() });
-    actionsCoreGetInput.mockReturnValue('test');
+    actionsCoreGetInput.mockImplementation((val: string): string => val === 'buildspec' ? '{}' : 'test');
     const error = new Error('test error');
     cancelBuild.mockImplementation(() => {throw error;});
     jest.spyOn(process, 'exit').mockImplementation(jest.fn().mockName('Mock process.exit()') as never);
@@ -123,6 +124,7 @@ describe('CodeBuildJob class functionality', () => {
     actionsCoreGetInput.mockImplementation((val: string): string => {
       switch (val) {
         case 'projectName': return 'test';
+        case 'buildspec': return '{}';
         default: return '';
       }
     });

--- a/__tests__/src/index/main.ts
+++ b/__tests__/src/index/main.ts
@@ -1,34 +1,35 @@
 const mocks: Record<string, jest.Mock> = {
   actionsCoreInfo: jest.fn().mockName('Mock: "@actions/core".info()'),
   actionsCoreGetInput: jest.fn().mockName('Mock: "@actions/core".getInput()'),
+  actionsCoreGetBooleanInput: jest.fn().mockName('Mock: "@actions/core".getBooleanInput()'),
   actionsCoreSetFailed: jest.fn().mockName('Mock: "@actions/core".setFailed()'),
   actionsCoreError: jest.fn().mockName('Mock: "@actions/core".error()'),
   startBuild: jest.fn().mockName('Mock: "src/codebuildjob".CodeBuildJob.startBuild()'),
   cancelBuild: jest.fn().mockName('Mock: "src/codebuildjob".CodeBuildJob.cancelBuild()'),
 };
 
-const CodeBuildJobMock = jest.fn(() => ({
-  startBuild: mocks.startBuild,
-  cancelBuild: mocks.cancelBuild,
-}))
-
 jest.mock('@actions/core', () => ({
   info: mocks.actionsCoreInfo,
   getInput: mocks.actionsCoreGetInput,
+  getBooleanInput: mocks.actionsCoreGetBooleanInput,
   setFailed: mocks.actionsCoreSetFailed,
   error: mocks.actionsCoreError,
 }));
 
-jest.mock('../../../src/codebuildjob', () => ({
-  CodeBuildJob: CodeBuildJobMock,
-}));
-
 describe('CodeBuildJob class functionality', () => {
   const OLD_ENV = { ...process.env };
+  let CodeBuildJobMock: jest.Mock;
 
   beforeEach(() => {
-    jest.resetModules() // Most important - it clears the cache
     process.env = { ...OLD_ENV }; // Make a copy
+    CodeBuildJobMock = jest.fn(() => ({
+      startBuild: mocks.startBuild,
+      cancelBuild: mocks.cancelBuild,
+    }))
+
+    jest.mock('../../../src/codebuildjob', () => ({
+      CodeBuildJob: CodeBuildJobMock,
+    }));
   });
 
   afterAll(() => {
@@ -37,20 +38,34 @@ describe('CodeBuildJob class functionality', () => {
 
   afterEach(() => {
     Object.values(mocks).forEach(mock => mock.mockReset());
-    CodeBuildJobMock.mockReset();
+    jest.resetModules(); // Most important - it clears the cache
+    jest.unmock('../../../src/codebuildjob');
   });
 
   it('should trigger job successfully', async () => {
     process.env.INPUT_PROJECTNAME = 'test';
+    process.env.INPUT_BUILDSTATUSINTERVAL = '5000';
+    process.env.INPUT_DISPLAYBUILDLOGS = 'true';
+    process.env.INPUT_LOGSUPDATEINTERVAL = '5000';
+    process.env.INPUT_WAITTOBUILDEND = 'true';
     process.env.CODEBUILD__test__nested__variable = 'CODEBUILD__test_nested_variable';
     process.env.CODEBUILD__test__nested__bool = 'true';
     process.env.CODEBUILD__test__nested__number = '555';
 
-    const { startBuild, actionsCoreGetInput } = mocks;
+    const { startBuild, actionsCoreGetInput, actionsCoreGetBooleanInput } = mocks;
     startBuild.mockReturnValue({ catch: jest.fn() });
-    actionsCoreGetInput.mockReturnValue('test');
+    actionsCoreGetInput.mockImplementation((val: string) => {
+      switch (val) {
+        case 'projectName': return 'test';
+        case 'buildStatusInterval': return '5000';
+        case 'logsUpdateInterval': return '5000';
+        default: return '';
+      }
+    });
 
-    jest.requireMock('../../../src/index');
+    actionsCoreGetBooleanInput.mockReturnValue(true);
+
+    require('../../../src/index');
 
     expect(CodeBuildJobMock).toHaveBeenLastCalledWith({
       projectName: 'test',
@@ -61,6 +76,11 @@ describe('CodeBuildJob class functionality', () => {
           number: 555,
         },
       },
+    }, {
+      buildStatusInterval: 5000,
+      displayBuildLogs: true,
+      logsUpdateInterval: 5000,
+      waitToBuildEnd: true,
     })
   });
 
@@ -68,7 +88,7 @@ describe('CodeBuildJob class functionality', () => {
     const { startBuild, actionsCoreGetInput, cancelBuild } = mocks;
     startBuild.mockReturnValue({ catch: jest.fn() });
     actionsCoreGetInput.mockReturnValue('test');
-    jest.requireMock('../../../src/index');
+    require('../../../src/index');
 
     jest.spyOn(process, 'exit').mockImplementation(jest.fn().mockName('Mock process.exit()') as never);
     process.emit('SIGINT');
@@ -83,10 +103,48 @@ describe('CodeBuildJob class functionality', () => {
     cancelBuild.mockImplementation(() => {throw error;});
     jest.spyOn(process, 'exit').mockImplementation(jest.fn().mockName('Mock process.exit()') as never);
 
-    jest.requireMock('../../../src/index');
+    require('../../../src/index');
     process.emit('SIGINT');
 
     expect(cancelBuild).toBeCalled();
     expect(actionsCoreError).toHaveBeenLastCalledWith(error);
+  });
+
+  it('should use default values', async () => {
+    process.env.INPUT_PROJECTNAME = 'test';
+    process.env.INPUT_DISPLAYBUILDLOGS = 'true';
+    process.env.INPUT_WAITTOBUILDEND = 'true';
+    process.env.CODEBUILD__test__nested__variable = 'CODEBUILD__test_nested_variable';
+    process.env.CODEBUILD__test__nested__bool = 'true';
+    process.env.CODEBUILD__test__nested__number = '555';
+
+    const { startBuild, actionsCoreGetInput, actionsCoreGetBooleanInput } = mocks;
+    startBuild.mockReturnValue({ catch: jest.fn() });
+    actionsCoreGetInput.mockImplementation((val: string): string => {
+      switch (val) {
+        case 'projectName': return 'test';
+        default: return '';
+      }
+    });
+
+    actionsCoreGetBooleanInput.mockReturnValue(false);
+    require('../../../src/index');
+
+    expect(CodeBuildJobMock).toBeCalled();
+    expect(CodeBuildJobMock).toHaveBeenLastCalledWith({
+      projectName: 'test',
+      test: {
+        nested: {
+          variable: 'CODEBUILD__test_nested_variable',
+          bool: true,
+          number: 555,
+        },
+      },
+    }, {
+      buildStatusInterval: 5000,
+      displayBuildLogs: false,
+      logsUpdateInterval: 5000,
+      waitToBuildEnd: false,
+    });
   });
 });

--- a/__tests__/src/index/setFailed.ts
+++ b/__tests__/src/index/setFailed.ts
@@ -1,5 +1,6 @@
 const setFailedMocks: Record<string, jest.Mock> = {
   actionsCoreGetInput: jest.fn().mockName('Mock: "@actions/core".getInput()'),
+  actionsCoreGetBooleanInput: jest.fn().mockName('Mock: "@actions/core".getBooleanInput()'),
   actionsCoreSetFailed: jest.fn().mockName('Mock: "@actions/core".setFailed()'),
   startBuild: jest.fn().mockName('Mock: "src/codebuildjob".CodeBuildJob.startBuild()'),
 };
@@ -12,6 +13,7 @@ const setFailedCodeBuildJobMock = jest.fn(() => ({
 jest.mock('@actions/core', () => ({
   info: setFailedMocks.actionsCoreInfo,
   getInput: setFailedMocks.actionsCoreGetInput,
+  getBooleanInput: setFailedMocks.actionsCoreGetBooleanInput,
   setFailed: setFailedMocks.actionsCoreSetFailed,
 }));
 

--- a/__tests__/src/index/setFailed.ts
+++ b/__tests__/src/index/setFailed.ts
@@ -25,7 +25,7 @@ describe('Testing setFailed functionality', () => {
   it('should set job failed on startBuild() error', async () => {
     const { startBuild, actionsCoreGetInput, actionsCoreSetFailed } = setFailedMocks;
     startBuild.mockRejectedValue(new Error('test'));
-    actionsCoreGetInput.mockReturnValue('test');
+    actionsCoreGetInput.mockImplementation((val: string): string => val === 'buildspec' ? '{}' : 'test');
 
     jest.requireMock('../../../src/index');
     await new Promise(process.nextTick);

--- a/__tests__/src/logger/CloudWatchLogger.ts
+++ b/__tests__/src/logger/CloudWatchLogger.ts
@@ -61,7 +61,7 @@ describe('CloudWatchLogs Logger getEvents() method', () => {
       .mockReturnValueOnce(createAWSResponse({ events, nextForwardToken: 'blah' }))
       .mockReturnValueOnce(createAWSResponse({ events: [], nextForwardToken: 'blah' }))
 
-    const logger = new CloudWatchLogger({ logGroupName: 'log_group_name', logStreamName: 'log_stream_name' });
+    const logger = new CloudWatchLogger({ logGroupName: 'log_group_name', logStreamName: 'log_stream_name' }, { updateInterval: 5000 });
 
     await expect(logger['getEvents']()).resolves.toBeUndefined();
     expect(getLogEvents).toBeCalledTimes(3);
@@ -80,7 +80,7 @@ describe('CloudWatchLogs Logger getEvents() method', () => {
     } as AWSError;
 
     getLogEvents.mockReturnValue(createAWSReject(error));
-    const logger = new CloudWatchLogger({ logGroupName: 'log_group_name', logStreamName: 'log_stream_name' });
+    const logger = new CloudWatchLogger({ logGroupName: 'log_group_name', logStreamName: 'log_stream_name' }, { updateInterval: 5000 });
     const stopListenSpy = jest.spyOn(logger, 'stopListen');
 
     await expect(logger['getEvents']()).resolves.toBeUndefined();
@@ -95,7 +95,7 @@ describe('CloudWatchLogs Logger Timers', () => {
   let logger: CloudWatchLogger;
 
   beforeEach(() => {
-    logger = new CloudWatchLogger({ logGroupName: 'log_group_name', logStreamName: 'log_stream_name' });
+    logger = new CloudWatchLogger({ logGroupName: 'log_group_name', logStreamName: 'log_stream_name' }, { updateInterval: 5000 });
     logger['getEvents'] = jest.fn();
     jest.useFakeTimers();
   });

--- a/__tests__/src/logger/Logger.ts
+++ b/__tests__/src/logger/Logger.ts
@@ -31,13 +31,13 @@ describe('Decorator Logger functionality', () => {
   });
 
   beforeEach(() => {
-    logger = new Logger({ type: 'cloudwatch', logGroupName: 'log_group_name', logStreamName: 'log_stream_name' });
+    logger = new Logger({ type: 'cloudwatch', logGroupName: 'log_group_name', logStreamName: 'log_stream_name' }, { updateInterval: 5000 });
     logger['logger']['startListen'] = jest.fn().mockReturnValue(Promise.resolve());
     logger['logger']['stopListen'] = jest.fn();
   });
 
   it('should trigger error for unknown logger type', async () => {
-    expect(() => new Logger({ type: 'fake', logGroupName: 'log_group_name', logStreamName: 'log_stream_name' })).toThrowError('No found CloudWatch config for listening');
+    expect(() => new Logger({ type: 'fake', logGroupName: 'log_group_name', logStreamName: 'log_stream_name' }, { updateInterval: 5000 })).toThrowError('No found CloudWatch config for listening');
   });
 
   it('should exit with error on exception in startLogger', async () => {

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,22 @@ inputs:
   projectName:
     description: 'The name of the CodeBuild build project to start running a build'
     required: true
+  buildStatusInterval:
+    description: 'Interval in milliseconds to control how often should be checked status of build'
+    required: false
+    default: '5000'
+  logsUpdateInterval:
+    description: 'Interval in milliseconds to control how often should be checked new events in logs stream'
+    required: false
+    default: '5000'
+  waitToBuildEnd:
+    description: 'Wait till AWS CodeBuild job will be finished'
+    required: false
+    default: 'true'
+  displayBuildLogs:
+    description: 'Display AWS CodeBuild logs output in the GitHub Actions logs output'
+    required: false
+    default: 'true'
 outputs:
   id:
     description: 'The unique ID for the build'

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Display AWS CodeBuild logs output in the GitHub Actions logs output'
     required: false
     default: 'true'
+  buildspec:
+    description: 'Custom buildSpec job overrides in the valid JSON format'
+    required: false
+    default: '{}'
 outputs:
   id:
     description: 'The unique ID for the build'

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ const config = nconf.env({
 
 const job = new CodeBuildJob({
   projectName: core.getInput('projectName'),
+  ...JSON.parse(core.getInput('buildspec')),
   ...config.get('CODEBUILD'),
 }, {
   buildStatusInterval: Number(core.getInput('buildStatusInterval') || '5000'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,11 @@ const config = nconf.env({
 const job = new CodeBuildJob({
   projectName: core.getInput('projectName'),
   ...config.get('CODEBUILD'),
+}, {
+  buildStatusInterval: Number(core.getInput('buildStatusInterval') || '5000'),
+  logsUpdateInterval: Number(core.getInput('logsUpdateInterval') || '5000'),
+  waitToBuildEnd: !!core.getBooleanInput('waitToBuildEnd'),
+  displayBuildLogs: !!core.getBooleanInput('displayBuildLogs'),
 });
 
 job.startBuild().catch(error => core.setFailed(error as Error));

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -52,11 +52,15 @@ class CloudWatchLogger {
   /**
    * Create a new instance of CloudWatchLogs stream logger listener
    * @param { logGroupName: string, logStreamName: string } params
+   * @param { updateInterval: number } options
+   * @param {string} options.updateInterval - Interval in milliseconds to track logs data updates
    */
-  constructor(params: { logGroupName: string, logStreamName: string }) {
+  constructor(params: { logGroupName: string, logStreamName: string }, options: { updateInterval: number }) {
     debug('[CloudWatchLogger] Created new CloudWatchLogger logger instance with parameters:', params);
 
     this.params = params;
+    this.timeoutDelay = options.updateInterval;
+
     this.getEvents = this.getEvents.bind(this);
     this.startListen = this.startListen.bind(this);
   }
@@ -165,17 +169,19 @@ class Logger {
   /**
    * Creates a new logger instance
    * @param { type: string, logGroupName: string, logStreamName: string } params
+   * @param { updateInterval: number } options
+   * @param {string} options.updateInterval - Interval in milliseconds to track logs data updates
    * @param {string} params.type - Type of connector that required to be launched
    * @param {string} params.logGroupName - CloudWatch Logs group name
    * @param {string} params.logStreamName - CloudWatch Stream name in provided CloudWatch Logs group name
    */
-  constructor(protected readonly params: { type: string, logGroupName: string, logStreamName: string }) {
+  constructor(protected readonly params: { type: string, logGroupName: string, logStreamName: string }, options: { updateInterval: number }) {
     debug('[Logger] Creating a new Logger wrapper instance with parameters:', params);
 
     const { type, logGroupName, logStreamName } = params;
     if (type === 'cloudwatch') {
       debug('[Logger] Creating new CloudWatchLogger instance with parameters:', params);
-      this.logger = new CloudWatchLogger({ logGroupName, logStreamName });
+      this.logger = new CloudWatchLogger({ logGroupName, logStreamName }, options);
     } else {
       throw new Error(`No found CloudWatch config for listening`);
     }


### PR DESCRIPTION
### Changes
* Added additional inputs support

## Inputs
```yaml
- name: Executing AWS CodeBuild task
  uses: dark-mechanicum/aws-codebuild@v1
  with:
    projectName: '<your-aws-codebuild-job-name-here>'
    buildStatusInterval: 5000
    logsUpdateInterval: 5000
    waitToBuildEnd: true
    displayBuildLogs: true
    buildspec: '{
      "environmentVariablesOverride":[
        { "name":"testEnvVar", "value":"Testing environment variable", "type": "PLAINTEXT" }
      ],
      "logsConfigOverride": {
        "cloudWatchLogs": {
          "status": "ENABLED"
        }
      }
    }'
```

* `projectName` [string] [required] - The name of the CodeBuild build project to start running a build
* `buildStatusInterval` [number] [optional] - Interval in milliseconds to control how often should be checked status of build
* `logsUpdateInterval` [number] [optional] - Interval in milliseconds to control how often should be checked new events in logs stream
* `waitToBuildEnd` [number] [boolean] - Wait till AWS CodeBuild job will be finished
* `displayBuildLogs` [number] [boolean] - Display AWS CodeBuild logs output in the GitHub Actions logs output
* `buildspec` [string] [optional] - Custom parameters to override job parameters in the valid JSON format. Full list of supported paramters you can find in the [CodeBuild.startBuild()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodeBuild.html#startBuild-property) documentation
